### PR TITLE
Add support for large-address aware applications

### DIFF
--- a/src/wow64ext.cpp
+++ b/src/wow64ext.cpp
@@ -85,7 +85,7 @@ extern "C" __declspec(dllexport) DWORD64 __cdecl X64Call(DWORD64 func, int argC,
     reg64 _r9 = { (argC > 0) ? argC--, va_arg(args, DWORD64) : 0 };
     reg64 _rax = { 0 };
 
-    reg64 restArgs = { (DWORD64)&va_arg(args, DWORD64) };
+    reg64 restArgs = { PTR_TO_DWORD64(&va_arg(args, DWORD64)) };
     
     // conversion to QWORD for easier use in inline assembly
     reg64 _argC = { (DWORD64)argC };
@@ -420,11 +420,11 @@ extern "C" __declspec(dllexport) DWORD64 __cdecl GetProcAddress64(DWORD64 hModul
     }
 
     _UNICODE_STRING_T<DWORD64> fName = { 0 };
-    fName.Buffer = (DWORD64)funcName;
+    fName.Buffer = PTR_TO_DWORD64(funcName);
     fName.Length = (WORD)strlen(funcName);
     fName.MaximumLength = fName.Length + 1;
     DWORD64 funcRet = 0;
-    X64Call(_LdrGetProcedureAddress, 4, (DWORD64)hModule, (DWORD64)&fName, (DWORD64)0, (DWORD64)&funcRet);
+    X64Call(_LdrGetProcedureAddress, 4, hModule, PTR_TO_DWORD64(&fName), (DWORD64)0, PTR_TO_DWORD64(&funcRet));
     return funcRet;
 }
 
@@ -438,7 +438,7 @@ extern "C" __declspec(dllexport) SIZE_T __cdecl VirtualQueryEx64(HANDLE hProcess
             return 0;
     }
     DWORD64 ret = 0;
-    DWORD64 status = X64Call(ntqvm, 6, (DWORD64)hProcess, lpAddress, (DWORD64)0, (DWORD64)lpBuffer, (DWORD64)dwLength, (DWORD64)&ret);
+    DWORD64 status = X64Call(ntqvm, 6, PTR_TO_DWORD64(hProcess), lpAddress, (DWORD64)0, PTR_TO_DWORD64(lpBuffer), (DWORD64)dwLength, PTR_TO_DWORD64(&ret));
 	if (STATUS_SUCCESS != status)
 		SetLastErrorFromX64Call(status);
 	return (SIZE_T)ret;
@@ -456,7 +456,7 @@ extern "C" __declspec(dllexport) DWORD64 __cdecl VirtualAllocEx64(HANDLE hProces
 
     DWORD64 tmpAddr = lpAddress;
     DWORD64 tmpSize = dwSize;
-    DWORD64 ret = X64Call(ntavm, 6, (DWORD64)hProcess, (DWORD64)&tmpAddr, (DWORD64)0, (DWORD64)&tmpSize, (DWORD64)flAllocationType, (DWORD64)flProtect);
+    DWORD64 ret = X64Call(ntavm, 6, PTR_TO_DWORD64(hProcess), PTR_TO_DWORD64(&tmpAddr), (DWORD64)0, PTR_TO_DWORD64(&tmpSize), (DWORD64)flAllocationType, (DWORD64)flProtect);
 	if (STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);
@@ -478,7 +478,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl VirtualFreeEx64(HANDLE hProcess, D
 
     DWORD64 tmpAddr = lpAddress;
     DWORD64 tmpSize = dwSize;
-    DWORD64 ret = X64Call(ntfvm, 4, (DWORD64)hProcess, (DWORD64)&tmpAddr, (DWORD64)&tmpSize, (DWORD64)dwFreeType);
+    DWORD64 ret = X64Call(ntfvm, 4, PTR_TO_DWORD64(hProcess), PTR_TO_DWORD64(&tmpAddr), PTR_TO_DWORD64(&tmpSize), (DWORD64)dwFreeType);
 	if (STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);
@@ -500,7 +500,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl VirtualProtectEx64(HANDLE hProcess
 
     DWORD64 tmpAddr = lpAddress;
     DWORD64 tmpSize = dwSize;
-    DWORD64 ret = X64Call(ntpvm, 5, (DWORD64)hProcess, (DWORD64)&tmpAddr, (DWORD64)&tmpSize, (DWORD64)flNewProtect, (DWORD64)lpflOldProtect);
+    DWORD64 ret = X64Call(ntpvm, 5, PTR_TO_DWORD64(hProcess), PTR_TO_DWORD64(&tmpAddr), PTR_TO_DWORD64(&tmpSize), (DWORD64)flNewProtect, PTR_TO_DWORD64(lpflOldProtect));
 	if (STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);
@@ -520,7 +520,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl ReadProcessMemory64(HANDLE hProces
             return 0;
     }
     DWORD64 numOfBytes = lpNumberOfBytesRead ? *lpNumberOfBytesRead : 0;
-    DWORD64 ret = X64Call(nrvm, 5, (DWORD64)hProcess, lpBaseAddress, (DWORD64)lpBuffer, (DWORD64)nSize, (DWORD64)&numOfBytes);
+    DWORD64 ret = X64Call(nrvm, 5, PTR_TO_DWORD64(hProcess), lpBaseAddress, PTR_TO_DWORD64(lpBuffer), (DWORD64)nSize, PTR_TO_DWORD64(&numOfBytes));
 	if (STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);
@@ -544,7 +544,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl WriteProcessMemory64(HANDLE hProce
             return 0;
     }
     DWORD64 numOfBytes = lpNumberOfBytesWritten ? *lpNumberOfBytesWritten : 0;
-    DWORD64 ret = X64Call(nrvm, 5, (DWORD64)hProcess, lpBaseAddress, (DWORD64)lpBuffer, (DWORD64)nSize, (DWORD64)&numOfBytes);
+    DWORD64 ret = X64Call(nrvm, 5, PTR_TO_DWORD64(hProcess), lpBaseAddress, PTR_TO_DWORD64(lpBuffer), (DWORD64)nSize, PTR_TO_DWORD64(&numOfBytes));
 	if (STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);
@@ -567,7 +567,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl GetThreadContext64(HANDLE hThread,
         if (0 == gtc)
             return 0;
     }
-    DWORD64 ret = X64Call(gtc, 2, (DWORD64)hThread, (DWORD64)lpContext);
+    DWORD64 ret = X64Call(gtc, 2, PTR_TO_DWORD64(hThread), PTR_TO_DWORD64(lpContext));
 	if(STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);
@@ -586,7 +586,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl SetThreadContext64(HANDLE hThread,
         if (0 == stc)
             return 0;
     }
-    DWORD64 ret = X64Call(stc, 2, (DWORD64)hThread, (DWORD64)lpContext);
+    DWORD64 ret = X64Call(stc, 2, PTR_TO_DWORD64(hThread), PTR_TO_DWORD64(lpContext));
 	if (STATUS_SUCCESS != ret)
 	{
 		SetLastErrorFromX64Call(ret);

--- a/src/wow64ext.h
+++ b/src/wow64ext.h
@@ -351,6 +351,10 @@ struct _CONTEXT64
 
 #pragma pack(pop)
 
+// Without the double casting, the pointer is sign extended, not zero extended,
+// which leads to invalid addresses with /LARGEADDRESSAWARE.
+#define PTR_TO_DWORD64(p) ((DWORD64)(ULONG_PTR)(p))
+
 #ifdef WOW64EXT_EXPORTS
 #   define SPEC dllexport
 #else


### PR DESCRIPTION
Large-address aware applications linked with the `/LARGEADDRESSAWARE` flag can have a user-mode address with its upper bit set. The current code sign-extends the pointer, e.g. `87aaeb58` to `ffffffff87aaeb58`, leading to an invalid pointer and likely to a crash.

I discovered this due to a bug report for [Windhawk](https://windhawk.net/):
https://github.com/ramensoftware/windhawk/issues/3

I came up with a small program which triggers the bug most of the time:
https://gist.github.com/m417z/7177d820252ab42f4d86c905589b6f05

Also, a similar notice regarding 32-bit to 64-bit pointer casting can be found [here](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefilegather):

> Assigning a pointer to the **Buffer** member will sign-extend the value if the code is compiled as 32-bits; this can break large-address aware applications running on systems configured with [4-Gigabyte Tuning](https://docs.microsoft.com/en-us/windows/desktop/Memory/4-gigabyte-tuning) or running under WOW64 on 64-bit Windows. Therefore, use the **PtrToPtr64** macro when assigning pointers to **Buffer**.