### PR TITLE
Fix const correctness for standards-conforming compiler behavior

### DIFF
--- a/src/wow64ext.cpp
+++ b/src/wow64ext.cpp
@@ -224,7 +224,7 @@ _move_0:                            ;//
     }
 }
 
-bool cmpMem64(void* dstMem, DWORD64 srcMem, size_t sz)
+bool cmpMem64(const void* dstMem, DWORD64 srcMem, size_t sz)
 {
     if ((nullptr == dstMem) || (0 == srcMem) || (0 == sz))
         return false;
@@ -295,7 +295,7 @@ DWORD64 getTEB64()
     return reg.v;
 }
 
-extern "C" __declspec(dllexport) DWORD64 __cdecl GetModuleHandle64(wchar_t* lpModuleName)
+extern "C" __declspec(dllexport) DWORD64 __cdecl GetModuleHandle64(const wchar_t* lpModuleName)
 {
 	if (!g_isWow64)
 		return 0;
@@ -409,7 +409,7 @@ extern "C" __declspec(dllexport) VOID __cdecl SetLastErrorFromX64Call(DWORD64 st
 	}
 }
 
-extern "C" __declspec(dllexport) DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, char* funcName)
+extern "C" __declspec(dllexport) DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, const char* funcName)
 {
     static DWORD64 _LdrGetProcedureAddress = 0;
     if (0 == _LdrGetProcedureAddress)
@@ -534,7 +534,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl ReadProcessMemory64(HANDLE hProces
     }
 }
 
-extern "C" __declspec(dllexport) BOOL __cdecl WriteProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesWritten)
+extern "C" __declspec(dllexport) BOOL __cdecl WriteProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPCVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesWritten)
 {
     static DWORD64 nrvm = 0;
     if (0 == nrvm)
@@ -577,7 +577,7 @@ extern "C" __declspec(dllexport) BOOL __cdecl GetThreadContext64(HANDLE hThread,
         return TRUE;
 }
 
-extern "C" __declspec(dllexport) BOOL __cdecl SetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext)
+extern "C" __declspec(dllexport) BOOL __cdecl SetThreadContext64(HANDLE hThread, const _CONTEXT64* lpContext)
 {
     static DWORD64 stc = 0;
     if (0 == stc)

--- a/src/wow64ext.h
+++ b/src/wow64ext.h
@@ -372,15 +372,15 @@ struct _CONTEXT64
 extern "C"
 {
 	__declspec(SPEC)DWORD64 __cdecl X64Call(DWORD64 func, int argC, ...);
-	__declspec(SPEC)DWORD64 __cdecl GetModuleHandle64(wchar_t* lpModuleName);
-	__declspec(SPEC)DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, char* funcName);
+	__declspec(SPEC)DWORD64 __cdecl GetModuleHandle64(const wchar_t* lpModuleName);
+	__declspec(SPEC)DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, const char* funcName);
 	__declspec(SPEC)SIZE_T __cdecl VirtualQueryEx64(HANDLE hProcess, DWORD64 lpAddress, MEMORY_BASIC_INFORMATION64* lpBuffer, SIZE_T dwLength);
 	__declspec(SPEC)DWORD64 __cdecl VirtualAllocEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
 	__declspec(SPEC)BOOL __cdecl VirtualFreeEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD dwFreeType);
 	__declspec(SPEC)BOOL __cdecl VirtualProtectEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flNewProtect, DWORD* lpflOldProtect);
 	__declspec(SPEC)BOOL __cdecl ReadProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesRead);
-	__declspec(SPEC)BOOL __cdecl WriteProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesWritten);
+	__declspec(SPEC)BOOL __cdecl WriteProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPCVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesWritten);
 	__declspec(SPEC)BOOL __cdecl GetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext);
-	__declspec(SPEC)BOOL __cdecl SetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext);
+	__declspec(SPEC)BOOL __cdecl SetThreadContext64(HANDLE hThread, const _CONTEXT64* lpContext);
 	__declspec(SPEC)VOID __cdecl SetLastErrorFromX64Call(DWORD64 status);
 }


### PR DESCRIPTION
These changes make the library compatible with [the `/permissive-` option](https://learn.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance). This option is implicitly set while using `/std:c++20`.